### PR TITLE
Group id feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ CREATE TABLE IF NOT EXISTS transactional_outbox (
     completion_date TIMESTAMP WITH TIME ZONE,
     attempts INT NOT NULL,
     event TEXT NOT NULL,
-    last_error TEXT
+    last_error TEXT,
+    group_id VARCHAR(255)
 );
 ```
 

--- a/acn-transactional-outbox-autoconfigure/src/main/java/it/gov/acn/autoconfigure/outbox/providers/data/OutboxSqlColumns.java
+++ b/acn-transactional-outbox-autoconfigure/src/main/java/it/gov/acn/autoconfigure/outbox/providers/data/OutboxSqlColumns.java
@@ -8,7 +8,8 @@ public enum OutboxSqlColumns {
     COMPLETION_DATE("completion_date"),
     ATTEMPTS("attempts"),
     EVENT("event"),
-    LAST_ERROR("last_error");
+    LAST_ERROR("last_error"),
+    GROUP_ID("group_id");
 
     private final String columnName;
 
@@ -29,6 +30,7 @@ public enum OutboxSqlColumns {
                 COMPLETION_DATE.getColumnName(),
                 ATTEMPTS.getColumnName(),
                 EVENT.getColumnName(),
-                LAST_ERROR.getColumnName());
+                LAST_ERROR.getColumnName(),
+                GROUP_ID.getColumnName());
     }
 }

--- a/acn-transactional-outbox-autoconfigure/src/main/java/it/gov/acn/autoconfigure/outbox/providers/data/postgres/PostgresJdbcDataProvider.java
+++ b/acn-transactional-outbox-autoconfigure/src/main/java/it/gov/acn/autoconfigure/outbox/providers/data/postgres/PostgresJdbcDataProvider.java
@@ -200,6 +200,7 @@ public class PostgresJdbcDataProvider implements DataProvider {
         item.setAttempts(resultSet.getInt(ATTEMPTS.getColumnName()));
         item.setEvent(resultSet.getString(EVENT.getColumnName()));
         item.setLastError(resultSet.getString(LAST_ERROR.getColumnName()));
+        item.setGroupId(resultSet.getString(GROUP_ID.getColumnName()));
         return item;
     }
 }

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/NullableIdGroupingStrategy.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/NullableIdGroupingStrategy.java
@@ -1,0 +1,47 @@
+package it.gov.acn.outbox.core.processor;
+
+import it.gov.acn.outbox.model.OutboxItem;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A grouping strategy that will pick the first (i.e. oldest) item in each
+ * group and will pick ALL the item in the null group.
+ * A group is defined by the group ID, items with the same group ID will be in
+ * the same group.
+ * The null group is the group whose group ID is null.
+ */
+public class NullableIdGroupingStrategy implements OutboxItemGroupingStrategy {
+
+    @Override
+    public List<OutboxItem> execute(List<OutboxItem> outstandingItems) {
+        //Found a test requiring this
+        if (outstandingItems == null) {
+            return null;
+        }
+
+        //Map from each group ID to a list of items
+        //Stupid groupingBy collector requires non-null keys
+        var itemsByGroupId = outstandingItems
+                .stream()
+                .collect(Collectors.groupingBy(item -> Optional.ofNullable(item.getGroupId())));
+
+        //All the items with a null group ID
+        var itemsWithoutGroupId = itemsByGroupId.getOrDefault(Optional.<String>empty(), List.of());
+
+        //The first of each list (except the list associated with a null group ID)
+        itemsByGroupId.remove(Optional.<String>empty());
+        var firstsOfEachGroupId = itemsByGroupId
+                .values()
+                .stream()
+                .map(items -> Collections.min(items, Comparator.comparing(OutboxItem::getCreationDate)))
+                .toList();
+
+        //The concatenation of the two lists
+        var result = new ArrayList<OutboxItem>();
+        result.addAll(itemsWithoutGroupId);
+        result.addAll(firstsOfEachGroupId);
+        return result;
+    }
+}

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/OutboxItemGroupingStrategy.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/OutboxItemGroupingStrategy.java
@@ -1,0 +1,14 @@
+package it.gov.acn.outbox.core.processor;
+
+import it.gov.acn.outbox.model.OutboxItem;
+
+import java.util.List;
+
+public interface OutboxItemGroupingStrategy {
+    /**
+      * Group outbox items based on the concrete implementation of a strategy
+      * @param outstandingItems list of outbox items to group
+      *  @return filtered list of outbox items
+      */
+    List<OutboxItem> execute(List<OutboxItem> outstandingItems);
+}

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/OutboxProcessor.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/OutboxProcessor.java
@@ -1,20 +1,16 @@
 package it.gov.acn.outbox.core.processor;
 
 import it.gov.acn.outbox.core.observability.OutboxMetricsCollector;
+import it.gov.acn.outbox.model.OutboxItem;
+import it.gov.acn.outbox.model.Sort;
 import it.gov.acn.outbox.provider.DataProvider;
 import it.gov.acn.outbox.provider.LockingProvider;
-import it.gov.acn.outbox.model.OutboxItem;
 import it.gov.acn.outbox.provider.OutboxItemHandlerProvider;
-import it.gov.acn.outbox.model.Sort;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.List;
 
 public class OutboxProcessor {
     private final Logger logger = LoggerFactory.getLogger(OutboxProcessor.class);

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/DatabaseOutboxEventRecorder.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/DatabaseOutboxEventRecorder.java
@@ -24,7 +24,7 @@ public class DatabaseOutboxEventRecorder implements OutboxEventRecorder {
     }
 
     @Override
-    public void recordEvent(Object event, String type) {
+    public void recordEvent(Object event, String type, String groupId) {
         this.transactionManagerProvider.executeInTransaction(()->{
             OutboxItem entry = new OutboxItem();
             Instant now = Instant.now();
@@ -33,6 +33,7 @@ public class DatabaseOutboxEventRecorder implements OutboxEventRecorder {
             entry.setCreationDate(now);
             entry.setAttempts(0);
             entry.setEvent(serializeToJson(event));
+            entry.setGroupId(groupId);
             dataProvider.save(entry);
             this.outboxMetricsCollector.incrementQueued();
         });

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/DummyOutboxEventRecorder.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/DummyOutboxEventRecorder.java
@@ -6,7 +6,9 @@ import org.slf4j.LoggerFactory;
 public class DummyOutboxEventRecorder implements OutboxEventRecorder {
     private final Logger logger = LoggerFactory.getLogger(DummyOutboxEventRecorder.class);
     @Override
-    public void recordEvent(Object event, String type) {
-        logger.debug("[DummyOutboxEventRecorder.recordEvent] Event to save: "+event.toString());
+    public void recordEvent(Object event, String type, String groupId) {
+        logger.debug("[DummyOutboxEventRecorder.recordEvent] Event to save: {} (group id: {})",
+                event.toString(),
+                groupId);
     }
 }

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/OutboxEventRecorder.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/OutboxEventRecorder.java
@@ -1,5 +1,9 @@
 package it.gov.acn.outbox.core.recorder;
 
 public interface OutboxEventRecorder {
-    void recordEvent(Object event, String type);
+    void recordEvent(Object event, String type, String groupId);
+
+    default void recordEvent(Object event, String type) {
+        recordEvent(event, type, null);
+    }
 }

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/model/OutboxItem.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/model/OutboxItem.java
@@ -1,6 +1,7 @@
 package it.gov.acn.outbox.model;
 
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.UUID;
 
 public class OutboxItem {
@@ -12,6 +13,8 @@ public class OutboxItem {
     private int attempts;
     private String event;
     private String lastError;
+
+    private String groupId;
 
     public UUID getId() {
         return id;
@@ -76,4 +79,8 @@ public class OutboxItem {
     public void setLastError(String lastError) {
         this.lastError = lastError;
     }
+
+    public String getGroupId() { return groupId; }
+
+    public void setGroupId(String groupId) { this.groupId = groupId; }
 }

--- a/acn-transactional-outbox-core/src/main/test/java/it/gov/acn/outbox/core/processor/NullableIdGroupingStrategyTest.java
+++ b/acn-transactional-outbox-core/src/main/test/java/it/gov/acn/outbox/core/processor/NullableIdGroupingStrategyTest.java
@@ -1,0 +1,164 @@
+package it.gov.acn.outbox.core.processor;
+
+import it.gov.acn.outbox.model.OutboxItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NullableIdGroupingStrategyTest {
+
+    private NullableIdGroupingStrategy nullableIdGroupingStrategy;
+
+    @BeforeEach
+    public void setup() {
+        nullableIdGroupingStrategy = new NullableIdGroupingStrategy();
+    }
+
+    @Test
+    public void given_no_outstanding_items_when_execute_then_return_empty() {
+        List<OutboxItem> result = nullableIdGroupingStrategy.execute(Collections.emptyList());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void given_only_null_group_id_items_when_execute_then_return_all() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId(null);
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId(null);
+        outboxItem2.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.execute(List.of(outboxItem1, outboxItem2));
+        assertEquals(2, result.size());
+        assertTrue(result.containsAll(List.of(outboxItem1, outboxItem2)));
+    }
+
+    @Test
+    public void given_single_non_null_group_id_with_1item_when_execute_then_return_it() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.execute(List.of(outboxItem1));
+        assertEquals(1, result.size());
+        assertEquals(outboxItem1, result.get(0));
+    }
+
+    @Test
+    public void given_single_non_null_group_id_with_2items_when_execute_then_return_oldest() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.execute(List.of(outboxItem2, outboxItem1));
+        assertEquals(1, result.size());
+        assertEquals(outboxItem1, result.get(0));
+    }
+
+    @Test
+    public void given_2non_null_group_ids_with_2items_each_when_execute_then_return_oldests() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId("group2");
+        outboxItem3.setCreationDate(Instant.now().minus(20, ChronoUnit.MINUTES));
+        var outboxItem4 = new OutboxItem();
+        outboxItem4.setGroupId("group2");
+        outboxItem4.setCreationDate(Instant.now().minus(15, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.execute(List.of(outboxItem2, outboxItem1, outboxItem4, outboxItem3));
+        assertEquals(2, result.size());
+        assertTrue(result.containsAll(List.of(outboxItem1, outboxItem3)));
+    }
+
+    @Test
+    public void given_2non_null_group_ids_with_2items_each_and_the_null_group_when_execute_then_return_oldests_and_all_nulls() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId("group2");
+        outboxItem3.setCreationDate(Instant.now().minus(20, ChronoUnit.MINUTES));
+        var outboxItem4 = new OutboxItem();
+        outboxItem4.setGroupId("group2");
+        outboxItem4.setCreationDate(Instant.now().minus(15, ChronoUnit.MINUTES));
+
+        var outboxItem5 = new OutboxItem();
+        outboxItem5.setGroupId(null);
+        outboxItem5.setCreationDate(Instant.now().minus(30, ChronoUnit.MINUTES));
+        var outboxItem6 = new OutboxItem();
+        outboxItem6.setGroupId(null);
+        outboxItem6.setCreationDate(Instant.now().minus(25, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.execute(
+                List.of(outboxItem2, outboxItem1, outboxItem4, outboxItem3, outboxItem5, outboxItem6));
+        assertEquals(4, result.size());
+        assertTrue(result.containsAll(List.of(outboxItem1, outboxItem3, outboxItem5, outboxItem6)));
+    }
+
+    @Test
+    public void given_2items_with_same_date_when_execute_return_any() {
+        var date = Instant.now().minus(10, ChronoUnit.MINUTES);
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(date);
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(date);
+
+
+
+        var result = nullableIdGroupingStrategy.execute(
+                List.of(outboxItem2, outboxItem1));
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).equals(outboxItem1) || result.get(0).equals(outboxItem2));
+    }
+
+    @Test
+    public void given_2items_with_same_date_and_null_group_when_execute_return_any_and_all() {
+        var date = Instant.now().minus(10, ChronoUnit.MINUTES);
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(date);
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(date);
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId(null);
+        outboxItem3.setCreationDate(date);
+        var outboxItem4 = new OutboxItem();
+        outboxItem4.setGroupId(null);
+        outboxItem4.setCreationDate(date);
+
+        var result = nullableIdGroupingStrategy.execute(
+                List.of(outboxItem2, outboxItem1, outboxItem4, outboxItem3));
+        assertEquals(3, result.size());
+        assertTrue(result.contains(outboxItem1) || result.contains(outboxItem2));
+        assertTrue(result.containsAll(List.of(outboxItem3, outboxItem4)));
+    }
+
+    @Test
+    public void given_null_list_when_execute_then_return_null() {
+        assertNull(nullableIdGroupingStrategy.execute(null));
+    }
+
+}

--- a/acn-transactional-outbox-core/src/main/test/java/it/gov/acn/outbox/core/processor/OutboxProcessorTest.java
+++ b/acn-transactional-outbox-core/src/main/test/java/it/gov/acn/outbox/core/processor/OutboxProcessorTest.java
@@ -16,6 +16,9 @@ import it.gov.acn.outbox.provider.DataProvider;
 import it.gov.acn.outbox.provider.LockingProvider;
 import it.gov.acn.outbox.model.OutboxItem;
 import it.gov.acn.outbox.provider.OutboxItemHandlerProvider;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -78,6 +81,83 @@ public class OutboxProcessorTest {
         outboxProcessor.process();
         verify(dataProvider, times(1)).find(anyBoolean(), anyInt(), any());
         verify(outboxItemHandlerProvider, times(1)).handle(outboxItem);
+    }
+
+    @Test
+    public void given_outstanding_items_with_group_ids_when_process_then_verify_handle_them() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId("group2");
+        outboxItem3.setCreationDate(Instant.now().minus(30, ChronoUnit.MINUTES));
+
+        when(dataProvider.find(anyBoolean(), anyInt(), any())).thenReturn(
+                List.of(outboxItem1, outboxItem3, outboxItem2));
+        outboxProcessor.process();
+        verify(dataProvider, times(1)).find(anyBoolean(), anyInt(), any());
+        verify(outboxItemHandlerProvider, times(0)).handle(outboxItem1);
+        verify(outboxItemHandlerProvider, times(1)).handle(outboxItem2);
+        verify(outboxItemHandlerProvider, times(1)).handle(outboxItem3);
+    }
+
+    @Test
+    public void given_outstanding_items_with_group_ids_and_failed_when_process_then_verify_handle_them() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        outboxItem2.setAttempts(outboxConfiguration.getMaxAttempts()+1);
+        outboxItem2.setLastAttemptDate(Instant.now().plus(10, ChronoUnit.HOURS));
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId("group2");
+        outboxItem3.setCreationDate(Instant.now().minus(30, ChronoUnit.MINUTES));
+
+        when(dataProvider.find(anyBoolean(), anyInt(), any())).thenReturn(
+                List.of(outboxItem1, outboxItem3, outboxItem2));
+        outboxProcessor.process();
+        verify(dataProvider, times(1)).find(anyBoolean(), anyInt(), any());
+        verify(outboxItemHandlerProvider, times(0)).handle(outboxItem1);
+        verify(outboxItemHandlerProvider, times(0)).handle(outboxItem2);
+        verify(outboxItemHandlerProvider, times(1)).handle(outboxItem3);
+    }
+
+    @Test
+    public void given_outstanding_items_with_group_ids_and_null_group_and_failed_when_process_then_verify_handle_them() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        outboxItem2.setAttempts(outboxConfiguration.getMaxAttempts()+1);
+        outboxItem2.setLastAttemptDate(Instant.now().plus(10, ChronoUnit.HOURS));
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId("group2");
+        outboxItem3.setCreationDate(Instant.now().minus(30, ChronoUnit.MINUTES));
+        var outboxItem4 = new OutboxItem();
+        outboxItem4.setGroupId(null);
+        outboxItem4.setCreationDate(Instant.now().minus(30, ChronoUnit.MINUTES));
+        var outboxItem5 = new OutboxItem();
+        outboxItem5.setGroupId(null);
+        outboxItem5.setAttempts(outboxConfiguration.getMaxAttempts()+1);
+        outboxItem5.setLastAttemptDate(Instant.now().plus(10, ChronoUnit.HOURS));
+        outboxItem5.setCreationDate(Instant.now().minus(60, ChronoUnit.MINUTES));
+
+        when(dataProvider.find(anyBoolean(), anyInt(), any())).thenReturn(
+                List.of(outboxItem1, outboxItem3, outboxItem2, outboxItem5, outboxItem4));
+        outboxProcessor.process();
+        verify(dataProvider, times(1)).find(anyBoolean(), anyInt(), any());
+        verify(outboxItemHandlerProvider, times(0)).handle(outboxItem1);
+        verify(outboxItemHandlerProvider, times(0)).handle(outboxItem2);
+        verify(outboxItemHandlerProvider, times(1)).handle(outboxItem3);
+        verify(outboxItemHandlerProvider, times(1)).handle(outboxItem4);
+        verify(outboxItemHandlerProvider, times(0)).handle(outboxItem5);
     }
 
     @Test


### PR DESCRIPTION
Added a grouping phase to the outbox items processing. An OutboxItemGroupStrategy implementation will group the items based on an optional groupId passed at item creation (i.e. when calling recordEvent) and pick zero or more items for each group. The only implementation (so far) is the NullableIdGroupingStrategy that will pick the oldest member of each group unless the group id of the group is null, in this case ALL the items are picked. This, and a default recordEvent that will set the group ID to null, ensures backward compatibility.

Fixed a bug where Collectors.groupingBy doesn't accept null keys. Added a test suite for NullableIdGroupingStrategy

Added a few test in OutboxProcessorTest to test the grouping behaviour coupled with the backoff selection strategy.

Updated the PostgresJdbcDataProvider to fetch the group ID. Updated the README.md to include the group_id column.