### PR TITLE
Grouped processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ CREATE TABLE IF NOT EXISTS transactional_outbox (
     completion_date TIMESTAMP WITH TIME ZONE,
     attempts INT NOT NULL,
     event TEXT NOT NULL,
-    last_error TEXT
+    last_error TEXT,
+    group_id VARCHAR(255)
 );
 ```
 

--- a/acn-transactional-outbox-autoconfigure/src/main/java/it/gov/acn/autoconfigure/outbox/providers/data/OutboxSqlColumns.java
+++ b/acn-transactional-outbox-autoconfigure/src/main/java/it/gov/acn/autoconfigure/outbox/providers/data/OutboxSqlColumns.java
@@ -8,7 +8,8 @@ public enum OutboxSqlColumns {
     COMPLETION_DATE("completion_date"),
     ATTEMPTS("attempts"),
     EVENT("event"),
-    LAST_ERROR("last_error");
+    LAST_ERROR("last_error"),
+    GROUP_ID("group_id");
 
     private final String columnName;
 
@@ -29,6 +30,7 @@ public enum OutboxSqlColumns {
                 COMPLETION_DATE.getColumnName(),
                 ATTEMPTS.getColumnName(),
                 EVENT.getColumnName(),
-                LAST_ERROR.getColumnName());
+                LAST_ERROR.getColumnName(),
+                GROUP_ID.getColumnName());
     }
 }

--- a/acn-transactional-outbox-autoconfigure/src/main/java/it/gov/acn/autoconfigure/outbox/providers/data/postgres/PostgresJdbcDataProvider.java
+++ b/acn-transactional-outbox-autoconfigure/src/main/java/it/gov/acn/autoconfigure/outbox/providers/data/postgres/PostgresJdbcDataProvider.java
@@ -200,6 +200,7 @@ public class PostgresJdbcDataProvider implements DataProvider {
         item.setAttempts(resultSet.getInt(ATTEMPTS.getColumnName()));
         item.setEvent(resultSet.getString(EVENT.getColumnName()));
         item.setLastError(resultSet.getString(LAST_ERROR.getColumnName()));
+        item.setGroupId(resultSet.getString(GROUP_ID.getColumnName()));
         return item;
     }
 }

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/ExponentialBackoffStrategy.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/ExponentialBackoffStrategy.java
@@ -4,7 +4,6 @@ import it.gov.acn.outbox.model.OutboxItem;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 
 public class ExponentialBackoffStrategy implements OutboxItemSelectionStrategy{
     private final int backoffBase;
@@ -13,29 +12,22 @@ public class ExponentialBackoffStrategy implements OutboxItemSelectionStrategy{
         this.backoffBase = backoffBase;
     }
 
-     /**
-      * Select outbox items that have not yet been attempted or have completed the exponential backoff period
-      * @param outstandingItems list of outbox items to filter
-     *                    @return filtered list of outbox items
-     */
     @Override
-    public List<OutboxItem> execute(List<OutboxItem> outstandingItems) {
-        if(outstandingItems==null || outstandingItems.isEmpty()){
-            return outstandingItems;
-        }
-        Instant now = Instant.now();
-        return outstandingItems.stream().filter(oe->{
-            // outbox items that have never been attempted are always accepted
-            if(oe.getAttempts()==0 ||  oe.getLastAttemptDate()==null){
-                return true;
-            }
-            // accepting only outbox for which the current backoff period has expired
-            // the backoff period is calculated as base^attempts
-            Instant backoffProjection = oe.getLastAttemptDate()
-                    .plus(Duration.ofMinutes((long) Math.pow(backoffBase, oe.getAttempts())));
+    public boolean filter(OutboxItem item) {
 
-            // if the projection is before now, it's time to retry, i.e. the backoff period has expired
-            return backoffProjection.isBefore(now);
-        }).toList();
+        Instant now = Instant.now();
+
+        // outbox items that have never been attempted are always accepted
+        if(item.getAttempts()==0 ||  item.getLastAttemptDate()==null){
+            return true;
+        }
+
+        // accepting only outbox for which the current backoff period has expired
+        // the backoff period is calculated as base^attempts
+        Instant backoffProjection = item.getLastAttemptDate()
+                .plus(Duration.ofMinutes((long) Math.pow(backoffBase, item.getAttempts())));
+
+        // if the projection is before now, it's time to retry, i.e. the backoff period has expired
+        return backoffProjection.isBefore(now);
     }
 }

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/NullableIdGroupingStrategy.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/NullableIdGroupingStrategy.java
@@ -1,0 +1,54 @@
+package it.gov.acn.outbox.core.processor;
+
+import it.gov.acn.outbox.model.OutboxItem;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A grouping strategy that will pick the first (i.e. oldest) item in each
+ * group and will pick ALL the item in the null group.
+ * A group is defined by the group ID, items with the same group ID will be in
+ * the same group.
+ * The null group is the group whose group ID is null.
+ */
+public class NullableIdGroupingStrategy implements OutboxItemGroupingStrategy {
+
+    @Override
+    public List<List<OutboxItem>> group(List<OutboxItem> outstandingItems) {
+        //Found a test requiring this
+        if (outstandingItems == null) {
+            return null;
+        }
+
+        //Map from each group ID to a list of items
+        //Stupid groupingBy collector requires non-null keys
+        var itemsByGroupId = outstandingItems
+                .stream()
+                .collect(Collectors.groupingBy(item -> Optional.ofNullable(item.getGroupId())));
+
+        //All the items with a null group ID are a group by themselves
+        var itemsWithoutGroupId = itemsByGroupId.getOrDefault(Optional.<String>empty(), List.of())
+                .stream()
+                .map(List::of)
+                .toList();
+
+        //Remove the null group
+        itemsByGroupId.remove(Optional.<String>empty());
+
+        //The concatenation of the two lists (if not empty)
+        var result = new ArrayList<List<OutboxItem>>();
+
+        if ( ! itemsWithoutGroupId.isEmpty()) {
+            result.addAll(itemsWithoutGroupId);
+        }
+
+        if ( ! itemsByGroupId.isEmpty()) {
+            //We DON'T sort each group by creation date because
+            //groupingBy preserve the order (if the downstream collector is in order, which
+            //toList is)
+            result.addAll(List.copyOf(itemsByGroupId.values()));
+        }
+        return result;
+    }
+}

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/OutboxItemGroupingStrategy.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/OutboxItemGroupingStrategy.java
@@ -1,0 +1,14 @@
+package it.gov.acn.outbox.core.processor;
+
+import it.gov.acn.outbox.model.OutboxItem;
+
+import java.util.List;
+
+public interface OutboxItemGroupingStrategy {
+    /**
+      * Group outbox items based on the concrete implementation of a strategy
+      * @param outstandingItems list of outbox items to group, sorted by creation date ascending
+      *  @return filtered list of outbox items
+      */
+    List<List<OutboxItem>> group(List<OutboxItem> outstandingItems);
+}

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/OutboxItemSelectionStrategy.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/processor/OutboxItemSelectionStrategy.java
@@ -7,8 +7,17 @@ import java.util.List;
 public interface OutboxItemSelectionStrategy {
     /**
       * Select outbox items based on the concrete implementation of a strategy
-      * @param outstandingItems list of outbox items to filter
-     *                    @return filtered list of outbox items
+      * @param item the item to select
+     *  @return true to include the item in the processing pipeline
      */
-    List<OutboxItem> execute(List<OutboxItem> outstandingItems);
+    boolean filter(OutboxItem item);
+
+    /**
+     * Just a helper to work with a list of items
+     * @param items A list of items, sorted by creation date ascending
+     * @return A list of filtered items
+     */
+    default List<OutboxItem> filter(List<OutboxItem> items) {
+        return items == null ? null : items.stream().filter(this::filter).toList();
+    }
 }

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/DatabaseOutboxEventRecorder.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/DatabaseOutboxEventRecorder.java
@@ -24,7 +24,7 @@ public class DatabaseOutboxEventRecorder implements OutboxEventRecorder {
     }
 
     @Override
-    public void recordEvent(Object event, String type) {
+    public void recordEvent(Object event, String type, String groupId) {
         this.transactionManagerProvider.executeInTransaction(()->{
             OutboxItem entry = new OutboxItem();
             Instant now = Instant.now();
@@ -33,6 +33,7 @@ public class DatabaseOutboxEventRecorder implements OutboxEventRecorder {
             entry.setCreationDate(now);
             entry.setAttempts(0);
             entry.setEvent(serializeToJson(event));
+            entry.setGroupId(groupId);
             dataProvider.save(entry);
             this.outboxMetricsCollector.incrementQueued();
         });

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/DummyOutboxEventRecorder.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/DummyOutboxEventRecorder.java
@@ -6,7 +6,9 @@ import org.slf4j.LoggerFactory;
 public class DummyOutboxEventRecorder implements OutboxEventRecorder {
     private final Logger logger = LoggerFactory.getLogger(DummyOutboxEventRecorder.class);
     @Override
-    public void recordEvent(Object event, String type) {
-        logger.debug("[DummyOutboxEventRecorder.recordEvent] Event to save: "+event.toString());
+    public void recordEvent(Object event, String type, String groupId) {
+        logger.debug("[DummyOutboxEventRecorder.recordEvent] Event to save: {} (group id: {})",
+                event.toString(),
+                groupId);
     }
 }

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/OutboxEventRecorder.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/core/recorder/OutboxEventRecorder.java
@@ -1,5 +1,9 @@
 package it.gov.acn.outbox.core.recorder;
 
 public interface OutboxEventRecorder {
-    void recordEvent(Object event, String type);
+    void recordEvent(Object event, String type, String groupId);
+
+    default void recordEvent(Object event, String type) {
+        recordEvent(event, type, null);
+    }
 }

--- a/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/model/OutboxItem.java
+++ b/acn-transactional-outbox-core/src/main/java/it/gov/acn/outbox/model/OutboxItem.java
@@ -1,6 +1,7 @@
 package it.gov.acn.outbox.model;
 
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.UUID;
 
 public class OutboxItem {
@@ -12,6 +13,8 @@ public class OutboxItem {
     private int attempts;
     private String event;
     private String lastError;
+
+    private String groupId;
 
     public UUID getId() {
         return id;
@@ -76,4 +79,8 @@ public class OutboxItem {
     public void setLastError(String lastError) {
         this.lastError = lastError;
     }
+
+    public String getGroupId() { return groupId; }
+
+    public void setGroupId(String groupId) { this.groupId = groupId; }
 }

--- a/acn-transactional-outbox-core/src/main/test/java/it/gov/acn/outbox/core/processor/ExponentialBackoffStrategyTest.java
+++ b/acn-transactional-outbox-core/src/main/test/java/it/gov/acn/outbox/core/processor/ExponentialBackoffStrategyTest.java
@@ -33,7 +33,7 @@ public class ExponentialBackoffStrategyTest {
 
     @Test
     public void given_no_outstanding_items_when_execute_then_return_empty() {
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(Collections.emptyList());
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(Collections.emptyList());
         assertTrue(result.isEmpty());
     }
 
@@ -42,7 +42,7 @@ public class ExponentialBackoffStrategyTest {
         OutboxItem outboxItem = new OutboxItem();
         outboxItem.setAttempts(0);
         outboxItem.setLastAttemptDate(Instant.now().minusSeconds(10));
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertEquals(1, result.size());
     }
 
@@ -51,7 +51,7 @@ public class ExponentialBackoffStrategyTest {
         OutboxItem outboxItem = new OutboxItem();
         outboxItem.setAttempts(1);
         outboxItem.setLastAttemptDate(Instant.now());
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertTrue(result.isEmpty());
     }
 
@@ -65,7 +65,7 @@ public class ExponentialBackoffStrategyTest {
             Instant.now().minus(backoffBase, ChronoUnit.MINUTES)
                 .minus(1, ChronoUnit.SECONDS));
 
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertEquals(1, result.size());
     }
 
@@ -80,7 +80,7 @@ public class ExponentialBackoffStrategyTest {
             Instant.now().minus(backoffBase, ChronoUnit.MINUTES)
                 .plus(10, ChronoUnit.SECONDS));
 
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertEquals(0, result.size());
     }
 
@@ -94,7 +94,7 @@ public class ExponentialBackoffStrategyTest {
             Instant.now().minus(calculateBackoff(outboxItem.getAttempts(),backoffBase), ChronoUnit.MINUTES)
                 .minus(1, ChronoUnit.SECONDS));
 
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertEquals(1, result.size());
     }
 
@@ -108,13 +108,13 @@ public class ExponentialBackoffStrategyTest {
             Instant.now().minus(calculateBackoff(outboxItem.getAttempts(),backoffBase), ChronoUnit.MINUTES)
                 .plus(10, ChronoUnit.SECONDS));
 
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertEquals(0, result.size());
     }
 
     @Test
     public void given_null_list_when_execute_then_return_null() {
-        assertNull(exponentialBackoffStrategy.execute(null));
+        assertNull(exponentialBackoffStrategy.filter((List<OutboxItem>)null));
     }
 
     @Test
@@ -122,7 +122,7 @@ public class ExponentialBackoffStrategyTest {
         OutboxItem outboxItem = new OutboxItem();
         outboxItem.setAttempts(1);
         outboxItem.setLastAttemptDate(null);
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertEquals(1, result.size());
     }
 
@@ -131,7 +131,7 @@ public class ExponentialBackoffStrategyTest {
         OutboxItem outboxItem = new OutboxItem();
         outboxItem.setAttempts(-1);
         outboxItem.setLastAttemptDate(Instant.now().minusSeconds(10));
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertEquals(1, result.size());
     }
 
@@ -140,7 +140,7 @@ public class ExponentialBackoffStrategyTest {
         OutboxItem outboxItem = new OutboxItem();
         outboxItem.setAttempts(1);
         outboxItem.setLastAttemptDate(Instant.now().plusSeconds(10));
-        List<OutboxItem> result = exponentialBackoffStrategy.execute(List.of(outboxItem));
+        List<OutboxItem> result = exponentialBackoffStrategy.filter(List.of(outboxItem));
         assertTrue(result.isEmpty());
     }
 

--- a/acn-transactional-outbox-core/src/main/test/java/it/gov/acn/outbox/core/processor/NullableIdGroupingStrategyTest.java
+++ b/acn-transactional-outbox-core/src/main/test/java/it/gov/acn/outbox/core/processor/NullableIdGroupingStrategyTest.java
@@ -1,0 +1,183 @@
+package it.gov.acn.outbox.core.processor;
+
+import it.gov.acn.outbox.model.OutboxItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NullableIdGroupingStrategyTest {
+
+    private NullableIdGroupingStrategy nullableIdGroupingStrategy;
+
+    @BeforeEach
+    public void setup() {
+        nullableIdGroupingStrategy = new NullableIdGroupingStrategy();
+    }
+
+    @Test
+    public void given_no_outstanding_items_when_execute_then_return_empty() {
+        var result = nullableIdGroupingStrategy.group(Collections.emptyList());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void given_only_null_group_id_items_when_execute_then_return_all() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId(null);
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId(null);
+        outboxItem2.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.group(List.of(outboxItem1, outboxItem2));
+        assertEquals(2, result.size());
+        assertTrue(result.containsAll(List.of(List.of(outboxItem1), List.of(outboxItem2))));
+    }
+
+    @Test
+    public void given_single_non_null_group_id_with_1item_when_execute_then_return_it() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.group(List.of(outboxItem1));
+        assertEquals(1, result.size());
+        assertEquals(List.of(outboxItem1), result.get(0));
+    }
+
+
+    @Test
+    public void given_single_non_null_group_id_with_2items_when_execute_then_return_oldest() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.group(List.of(outboxItem1, outboxItem2));
+        assertEquals(1, result.size());
+        assertEquals(List.of(outboxItem1, outboxItem2), result.get(0));
+    }
+
+
+    @Test
+    public void given_2non_null_group_ids_with_2items_each_when_execute_then_return_oldests() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId("group2");
+        outboxItem3.setCreationDate(Instant.now().minus(20, ChronoUnit.MINUTES));
+        var outboxItem4 = new OutboxItem();
+        outboxItem4.setGroupId("group2");
+        outboxItem4.setCreationDate(Instant.now().minus(15, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.group(
+                List.of(outboxItem3, outboxItem4, outboxItem1, outboxItem2));
+
+        assertEquals(2, result.size());
+        assertEquals(2, result.get(0).size());
+        assertEquals(2, result.get(1).size());
+
+        var exp1 = List.of(outboxItem1, outboxItem2);
+        var exp2 = List.of(outboxItem3, outboxItem4);
+        assertTrue(result.containsAll(List.of(exp1, exp2)));
+
+    }
+
+    @Test
+    public void given_2non_null_group_ids_with_2items_each_and_the_null_group_when_execute_then_return_oldests_and_all_nulls() {
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(Instant.now().minus(10, ChronoUnit.MINUTES));
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(Instant.now().minus(5, ChronoUnit.MINUTES));
+
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId("group2");
+        outboxItem3.setCreationDate(Instant.now().minus(20, ChronoUnit.MINUTES));
+        var outboxItem4 = new OutboxItem();
+        outboxItem4.setGroupId("group2");
+        outboxItem4.setCreationDate(Instant.now().minus(15, ChronoUnit.MINUTES));
+
+        var outboxItem5 = new OutboxItem();
+        outboxItem5.setGroupId(null);
+        outboxItem5.setCreationDate(Instant.now().minus(30, ChronoUnit.MINUTES));
+        var outboxItem6 = new OutboxItem();
+        outboxItem6.setGroupId(null);
+        outboxItem6.setCreationDate(Instant.now().minus(25, ChronoUnit.MINUTES));
+
+        var result = nullableIdGroupingStrategy.group(
+                List.of(outboxItem5, outboxItem6, outboxItem3, outboxItem4, outboxItem1, outboxItem2));
+        assertEquals(4, result.size());
+        assertTrue(result.containsAll(
+                List.of(
+                        List.of(outboxItem1, outboxItem2),
+                        List.of(outboxItem3, outboxItem4),
+                        List.of(outboxItem5),
+                        List.of(outboxItem6)
+                )
+        ));
+    }
+
+    @Test
+    public void given_2items_with_same_date_when_execute_return_any() {
+        var date = Instant.now().minus(10, ChronoUnit.MINUTES);
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(date);
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(date);
+
+
+        var result = nullableIdGroupingStrategy.group(
+                List.of(outboxItem2, outboxItem1));
+        assertEquals(1, result.size());
+        assertEquals(List.of(List.of(outboxItem2, outboxItem1)), result);
+    }
+
+    @Test
+    public void given_2items_with_same_date_and_null_group_when_execute_return_any_and_all() {
+        var date = Instant.now().minus(10, ChronoUnit.MINUTES);
+        var outboxItem1 = new OutboxItem();
+        outboxItem1.setGroupId("group1");
+        outboxItem1.setCreationDate(date);
+        var outboxItem2 = new OutboxItem();
+        outboxItem2.setGroupId("group1");
+        outboxItem2.setCreationDate(date);
+        var outboxItem3 = new OutboxItem();
+        outboxItem3.setGroupId(null);
+        outboxItem3.setCreationDate(date);
+        var outboxItem4 = new OutboxItem();
+        outboxItem4.setGroupId(null);
+        outboxItem4.setCreationDate(date);
+
+        var result = nullableIdGroupingStrategy.group(
+                List.of(outboxItem2, outboxItem1, outboxItem4, outboxItem3));
+        assertEquals(3, result.size());
+        assertTrue(result.containsAll(List.of(
+                List.of(outboxItem2, outboxItem1),
+                List.of(outboxItem4),
+                List.of(outboxItem3)
+        )));
+    }
+
+    @Test
+    public void given_null_list_when_execute_then_return_null() {
+        assertNull(nullableIdGroupingStrategy.group(null));
+    }
+
+}


### PR DESCRIPTION
Rewritten the grouping logic. 

The outbox item are fetched from the persistence store in order of creation date, then they are grouped according to an OutboxItemGroupingStrategy implementation. 
Each group is then processed in order according to the creation date field. 
Each item in a group is checked for processing eligibility according to an OutboxItemSelectionStrategy implementation. 
If an item is not eligible for processing, the group processing stops (this is because eligibility is always temporary and the item may be processed later). 
If the item handler fails to handle an item, the group processing stops if, and only if, the error is temporary (i.e. the item is not put in the DLQ). 
In case of a permanent error, the group processing is not interrupted. 

Groups are not ordered among themselves, groups are returned in an implementation defined order.

The basic idea is to process items in each group in order even if one temporarily fail, thereby voluntarily introducing an head-of-line blocking. This items are first grouped to determine their relative order (in a group) and then, for each group, each one is processed until an ineligible item is found or an handling failed without requiring the item to be put in the DLQ.

The only available implementation of OutboxItemGroupingStrategy is NullableIdGroupingStrategy that groups each item according to its group id but put each item with a null group id in its own group. This emulates the legacy behaviour . 

The OutboxEventRecorder now takes an extra String parameter groupId. A default override without such parameter now exists to be used when groupId is null. 
The OutboxItemSelectionStrategy has been changed to filter single elements rather than a list, but a default method is provided for backward compatibility.
The functional method name of OutboxItemSelectionStrategy was changed from execute to filter.

Added a few test in OutboxProcessorTest to test the grouping behaviour coupled with the backoff selection strategy, along with a test suite for the NullableIdGroupingStrategy implementation.

Updated the PostgresJdbcDataProvider to fetch the group ID. 
Updated the README.md to include the group_id column.